### PR TITLE
In the event of a successful request, don't fire a timeout later.

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,18 +172,29 @@ var LGTV = function (config) {
 
             switch (type)  {
                 case 'request':
+                    // set callback timeout
+                    var timeoutId =
+                        setTimeout(function () {
+                            // remove callback first, in case the response
+                            // comes back while we're processing the error.
+                            delete callbacks[cid];
+
+                            // notify of the error.
+                            cb(new Error('timeout'));
+                        }, config.timeout);
+
                     callbacks[cid] = function (err, res) {
+                        // clear the timeout first, so the callback processing
+                        // time doesn't count against the timeout.
+                        clearTimeout(timeoutId);
+
+                        // call the callback
                         cb(err, res);
+
                         // remove callback after first call
                         delete callbacks[cid];
                     };
 
-                    // set callback timeout
-                    setTimeout(function () {
-                        cb(new Error('timeout'));
-                        // remove callback
-                        delete callbacks[cid];
-                    }, config.timeout);
                     break;
 
                 case 'subscribe':


### PR DESCRIPTION
Likewise, in the event of a timeout, don't fire a 'success' if it happens to come in while processing the timeout (much less likely).

I think this is a bug -- in my experience, the old version will always fire a timeout after 15s, even when the request completes successfully.  What do you think?  Feel free to accept/decline/discuss as you deem appropriate.
