### PR TITLE
No need to create a new directory if keyFile is specified.

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,6 +118,7 @@ var LGTV = function (config) {
         });
 
         connection.on('message', function (message) {
+            that.emit('message', message);
             var parsedMessage;
             if (message.type === 'utf8') {
                 if (message.utf8Data) {

--- a/index.js
+++ b/index.js
@@ -45,8 +45,11 @@ var LGTV = function (config) {
     config.reconnect = typeof config.reconnect === 'undefined' ? 5000 : config.reconnect;
     config.wsconfig = config.wsconfig || {keepalive: true, keepaliveInterval: 10000, dropConnectionOnKeepaliveTimeout: true, keepaliveGracePeriod: 5000};
     if (typeof config.clientKey === 'undefined') {
-        mkdirp(ppath('lgtv2'));
-        config.keyFile = (config.keyFile ? config.keyFile : ppath('lgtv2/keyfile-') + config.url.replace(/[a-z]+:\/\/([0-9a-zA-Z-_.]+):\d+/, '$1'));
+        if(!config.keyFile){
+            mkdirp(ppath('lgtv2'));
+            config.keyFile = ppath('lgtv2/keyfile-');
+        }
+        config.keyFile = config.keyFile + config.url.replace(/[a-z]+:\/\/([0-9a-zA-Z-_.]+):\d+/, '$1'));
         try {
             that.clientKey = fs.readFileSync(config.keyFile).toString();
         } catch (err) {}


### PR DESCRIPTION
Hi,

i noticed that even when the `keyFile` is specified a new `lgtv2` directory was created, which is a little bit unnecessary and might cause some issues if for some reason the home directory is not writable, in that case even when the `keyFile` was specified the code would crash. If `keyFile` is specified it should straight be used and no directory should be created.